### PR TITLE
Allow duplicate assignments 

### DIFF
--- a/R/helperscripts/assignments.R
+++ b/R/helperscripts/assignments.R
@@ -3,7 +3,6 @@
 getUnassigned <- function(assign_table){
     assigns <- assign_table[["assignment"]] #[assign_table$category == "Unassigned"]
     if (length(assigns) != 0){
-        print(assigns)
         return (assigns) 
     }
     return ()
@@ -89,7 +88,8 @@ createNestedCards <- function(flat_categories, category_levels) {
             )
         }
         style <- if (level > 1) "margin-left: 20px;" else ""
-        box(title = title, status = "primary", collapsible = TRUE, collapsed = !(level %in% c(1, 2)),  width = 12, div(style = style, content))
+        box(title = title, status = "primary", collapsible = TRUE, collapsed = FALSE #!(level %in% c(1, 2))
+            ,  width = 12, div(style = style, content))
         
     }
     

--- a/R/ui-components/policies.R
+++ b/R/ui-components/policies.R
@@ -45,7 +45,7 @@ Policies <- tabItem(tabName = "policies",
                                                         uiOutput("categoriesUI"),
                                                  ),
                                                  column(4,
-                                                        h4("New Assignments:", style = "margin-bottom: 20px;"),
+                                                        h4("Existing Assignments:", style = "margin-bottom: 20px;"),
                                                         uiOutput("unassigned")
                                                  )
                                              )


### PR DESCRIPTION
- [x] This change will allow you to add multiple times each assignment from the drop down menu of Category Modal. It keeps the list of assignments as well. I can add a counter to each assignment to specify how many times has been added to a category as we talked in the past. 
- [x] keep expanded all categories by default (not collapsed)
- [x] changed vocab from New Assignments to Existing Assignments  in policy tab.
- [ ] haven't added a counter next to each assignment -- it is currently very ambiguous whether an assignment is added to a category or not. It would be difficult to track 80-100 assignments at the moment.
- [ ] more testing... just in case.