### PR TITLE
Slip Days Functionality

### DIFF
--- a/R/helperscripts/assignments.R
+++ b/R/helperscripts/assignments.R
@@ -88,7 +88,13 @@ createNestedCards <- function(flat_categories, category_levels) {
             )
         }
         style <- if (level > 1) "margin-left: 20px;" else ""
-        box(title = title, status = "primary", collapsible = TRUE, collapsed = !(level %in% c(1, 2)),  width = 12, div(style = style, content))
+        
+        box(title = title, 
+            status = "primary", 
+            collapsible = TRUE, 
+            collapsed = !(level %in% c(1, 2)),  
+            width = 12, 
+            div(style = style, content))
         
     }
     

--- a/R/helperscripts/slip_days.R
+++ b/R/helperscripts/slip_days.R
@@ -1,0 +1,274 @@
+###### --------------- SLIP DAYS MODAL ------------- ####
+
+
+edit_slip_days_modal <- modalDialog(
+    tags$head(
+        tags$style(HTML('
+                .help-icon {
+                cursor: pointer;
+            }
+            .tooltip-box {
+                display: none;
+                position: absolute;
+                background-color: #f9f9f9;
+                border: 1px solid #d3d3d3;
+                padding: 10px;
+                width: 280px;
+                border-radius: 5px;
+                box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+                z-index: 100;
+                font-weight: normal;
+            }
+            .help-icon:hover + .tooltip-box {
+                display: block;
+            }
+            .custom-gear-btn {
+                background-color: transparent;
+                border: none;
+                color: #007bff;
+                font-size: 16px; 
+                cursor: pointer;
+                padding: 0px;
+                vertical-align: middle;
+            }
+             .custom-gear-btn:hover {
+                background-color: transparent;
+             }
+        '))
+    ),
+    title = h4("Edit Slip Days Policy"),
+    fluidRow(column(6,offset = 0,
+                    textInput("slip_days_policy_name", "Slip Days Name", value = "", width = "100%")
+    ),
+    column(6, offset = 0,
+           selectInput('order',
+                       label = div(style = "position:relative;", 
+                                   tags$span("Order: ", style = "font-weight: bold;"),
+                                   tags$i(class = "fas fa-info-circle help-icon"),
+                                   tags$div(class = "tooltip-box",
+                                            HTML("
+                                                <ul>
+                                                <li><b>Chronological:</b> The slip days are applied in chronological order and it is the default.  </li>
+                                                <li><b>Given:</b> It allotts slip days based on the order given in the policy file in `assignments` under `slipdays` with no regard to the chronological order of these assignments.</li>
+                                                </ul>
+                                                    ")
+                                   )
+                       ),
+                       selected = 'chronological',
+                       choices = c(
+                           'Chronological' = 'chronological',
+                           'Given' = 'given'
+                       )
+           )
+           
+    )),
+    selectizeInput("assignments", "Select Assignments:",
+                   choices = "", multiple = TRUE, width = "100%",
+                   options = list(create = TRUE)),
+    uiOutput("slip_days_modal"),
+    easyClose = TRUE,
+    footer = tagList(
+
+                  modalButton("Cancel"),
+                   actionButton("save_lateness", "Save", style = "color: white; background-color: #337ab7;")
+            )
+)
+
+###### --------------- LATENESS UI INSIDE MODAL ------------- ####
+
+generate_lateness_ui <- function(lateness){
+    renderUI({ 
+        lapply(1:as.integer(lateness$num_late_cats), function(i) {
+            fluidRow(
+                
+                column(width = 3, offset = 0,
+                       selectInput(paste0("lateness_preposition", i), NULL,
+                                   ifelse(i <= length(lateness$prepositions),
+                                          lateness$prepositions[i],
+                                          "Until"
+                                   ),
+                                   choices = c("Until", "After", "Between"))
+                ),
+                column(width = 2, offset = 0,
+                       textInput(paste0("start", i), label = NULL,
+                                 value = ifelse(i <= length(lateness$starts),
+                                                lateness$starts[i],
+                                                ""
+                                 ),
+                                 placeholder = "HH:MM:SS"),
+                       #custom json to handle special time input
+                       #file is saved in folder www
+                       tags$head(includeScript("www/timeInputHandler.js"))
+                ),
+                column(width = 2, offset = 0,
+                       conditionalPanel(
+                           condition = paste0("input.lateness_preposition",i, "== 'Between'"),
+                           textInput(paste0("end", i), label = NULL, 
+                                     value = ifelse(i <= length(lateness$ends),
+                                                    lateness$ends[i],
+                                                    ""
+                                     ),
+                                     placeholder = "HH:MM:SS"),
+                           #custom json to handle special time input
+                           #file is saved in folder www
+                           tags$head(includeScript("www/timeInputHandler.js"))
+                       )
+                ),
+                column(width = 3, offset = 0,
+                       selectInput(paste0("lateness_arithmetic", i), NULL, 
+                                   ifelse(i <= length(lateness$arithmetics),
+                                          lateness$arithmetics[i],
+                                          "Add"
+                                   ),
+                                   
+                                   choices = c('Add' = 'Add',
+                                               'Scale By' = 'Scale_by', 
+                                               'Set To' = 'Set_to'
+                                   )
+                                   
+                       )
+                ),
+                column(width = 2, offset = 0,
+                       numericInput(paste0("lateness_value", i), label = NULL,
+                                    value = ifelse(i <= length(lateness$values),
+                                                   lateness$values[i],
+                                                   0.03
+                                                   
+                                    )
+                       )
+                )
+            )
+        })
+    })
+}
+
+
+###### --------------- SLIP DAYS POLICIES UI ------------- ####
+
+# 
+# createLatenessCards <- function(lateness_table) {
+#     lapply(names(lateness_table), function(late_policy_name) {
+#         late_policy <- lateness_table[[late_policy_name]]
+#         i <- 0.5
+#         content <- lapply(late_policy, function(item) {
+#             # Type of lateness and its value
+#             i <<- i + 0.5
+#             policy_line <- if (names(item) == "between") {
+#                 # Special format for BETWEEN
+#                 
+#                 tags$div(
+#                     tags$strong(paste0("INTERVAL ", i)),
+#                     tags$br(),
+#                     tags$strong(ucfirst(names(item))), 
+#                     tags$br(),
+#                     tags$strong("From:"), item$between$from,
+#                     tags$br(),
+#                     tags$strong("To:"), item$between$to,
+#                     tags$br()
+#                 )
+#             } else if(names(item) %in% c("until", "after")){
+#                 tags$div(
+#                     tags$strong(paste0("INTERVAL ", i)),
+#                     tags$br(),
+#                     tags$strong(ucfirst(names(item))), ":", item,
+#                     tags$br()
+#                 )
+#             } else {
+#                 tags$div(
+#                     tags$strong(ucfirst(names(item))), ":", item,
+#                     tags$br()
+#                 )
+#             }
+#             policy_line
+#         })
+#         
+#         
+#         icons <- div(
+#             class = "category-title",
+#             style = "text-align: right;", 
+#             # late_policy_name,
+#             actionButton(paste0('lateness_delete_', late_policy_name), label = NULL, icon = icon("trash"), style = "background-color: transparent; margin-right: 10px;"),
+#             actionButton(paste0('lateness_edit_', late_policy_name), label = NULL, icon = icon("edit"), style = "background-color: transparent;")
+#         )
+#         
+#         content <- do.call(tagList, content)
+#         
+#         box(
+#             #title = title,
+#             status = "primary",
+#             width = 8,
+#             icons,
+#             content
+#             
+#         )
+#     })
+# }
+
+# Helper function to capitalize the first letter of each word
+# ucfirst <- function(s) {
+#     sapply(strsplit(s, " "), function(x) {
+#         paste(toupper(substring(x, 1, 1)), substring(x, 2), sep = "", collapse = " ")
+#     }, USE.NAMES = FALSE)
+# }
+# 
+# update_lateness <- function(policy_categories, cat_to_update, late_policy){
+#     index <- find_indices(policy_categories, cat_to_update)
+#     index_cmd <- paste0("policy_categories[[", paste(index, collapse = "]]$assignments[["), "]]$lateness <- late_policy")
+#     eval(parse(text = index_cmd))
+#     return(policy_categories)
+# }
+
+###### --------------- FUNCTION TO GENERATE A STRING FOR EACH POLICY ------------- ####
+# format_policy <- function(policy) {
+#     policy_strings <- c()
+#     
+#     # Loop through each item in the policy
+#     for (interval in policy) {
+#         # Handle the 'between' interval
+#         if (!is.null(interval$between)) {
+#             between_string <- sprintf("Between: FROM: %s TO: %s", interval$between$from, interval$between$to)
+#             policy_strings <- c(policy_strings, between_string)
+#         } 
+#         
+#         # Handle the 'until' interval
+#         if (!is.null(interval$until)) {
+#             until_string <- sprintf("Until: %s", interval$until)
+#             policy_strings <- c(policy_strings, until_string)
+#         }
+#         
+#         # Handle the 'after' interval
+#         if (!is.null(interval$after)) {
+#             after_string <- sprintf("After: %s", interval$after)
+#             policy_strings <- c(policy_strings, after_string)
+#         }
+#         
+#         # Handle the 'add' arithmetic 
+#         if (!is.null(interval$add)) {
+#             add_string <- sprintf("Add: %s", interval$add)
+#             policy_strings <- c(policy_strings, add_string)
+#         }
+#         
+#         # Handle the 'scale by' arithmetic 
+#         if (!is.null(interval$scale_by)) {
+#             scaleby_string <- sprintf("Scale By: %s", interval$scale_by)
+#             policy_strings <- c(policy_strings, scaleby_string)
+#         }
+#         
+#         # Handle the 'set to' arithmetic 
+#         if (!is.null(interval$set_to)) {
+#             setto_string <- sprintf("Set To: %s", interval$set_to)
+#             policy_strings <- c(policy_strings, setto_string)
+#         }
+#     }
+#     #does not create a new line...
+#     paste(policy_strings, collapse = " ")
+# }
+###### --------------- DELETE SLIP DAYS POLICY ------------- ####
+# confirm_delete_lateness <- modalDialog(
+#     h4("Are you sure you want to delete this lateness policy ?"),
+#     easyClose = TRUE,
+#     footer = tagList(
+#         actionButton("cancel", "Cancel"),
+#         actionButton("delete_late", "Delete"))
+#     
+# )

--- a/R/helperscripts/slip_days.R
+++ b/R/helperscripts/slip_days.R
@@ -1,6 +1,4 @@
 ###### --------------- SLIP DAYS MODAL ------------- ####
-
-
 edit_slip_days_modal <- modalDialog(
     tags$head(
         tags$style(HTML('
@@ -37,238 +35,85 @@ edit_slip_days_modal <- modalDialog(
         '))
     ),
     title = h4("Edit Slip Days Policy"),
-    fluidRow(column(6,offset = 0,
-                    textInput("slip_days_policy_name", "Slip Days Name", value = "", width = "100%")
-    ),
-    column(6, offset = 0,
-           selectInput('order',
-                       label = div(style = "position:relative;", 
-                                   tags$span("Order: ", style = "font-weight: bold;"),
-                                   tags$i(class = "fas fa-info-circle help-icon"),
-                                   tags$div(class = "tooltip-box",
-                                            HTML("
+    fluidRow(
+        column(6,
+               textInput("slip_days_policy_name", "Slip Days Policy Name", value = "", width = "100%")
+        ),
+        column(6,
+               selectInput('slip_days_order',
+                           label = div(style = "position:relative;", 
+                                       tags$span("Order: ", style = "font-weight: bold;"),
+                                       tags$i(class = "fas fa-info-circle help-icon"),
+                                       tags$div(class = "tooltip-box",
+                                                HTML("
                                                 <ul>
-                                                <li><b>Chronological:</b> The slip days are applied in chronological order and it is the default.  </li>
-                                                <li><b>Given:</b> It allotts slip days based on the order given in the policy file in `assignments` under `slipdays` with no regard to the chronological order of these assignments.</li>
-                                                </ul>
-                                                    ")
-                                   )
-                       ),
-                       selected = 'chronological',
-                       choices = c(
-                           'Chronological' = 'chronological',
-                           'Given' = 'given'
-                       )
-           )
-           
-    )),
-    selectizeInput("assignments", "Select Assignments:",
-                   choices = "", multiple = TRUE, width = "100%",
-                   options = list(create = TRUE)),
-    uiOutput("slip_days_modal"),
+                                                <li><b>Chronological:</b> Apply slip days in chronological order.</li>
+                                                <li><b>Given:</b> Use the order specified in the policy file.</li>
+                                                </ul>")
+                                       )
+                           ),
+                           selected = 'chronological',
+                           choices = c(
+                               'Chronological' = 'chronological',
+                               'Given' = 'given'
+                           )
+               )
+        )
+    ),
+    fluidRow(
+        column(6,
+               numericInput("num_slip_days", "Number of Slip Days Allowed", value = 0, min = 0)
+        )
+    ),
+    selectizeInput("assignments", "Select Assignments:", choices = NULL, multiple = TRUE, width = "100%"),
     easyClose = TRUE,
     footer = tagList(
-
-                  modalButton("Cancel"),
-                   actionButton("save_lateness", "Save", style = "color: white; background-color: #337ab7;")
-            )
+        modalButton("Cancel"),
+        actionButton("save_slip_days", "Save", style = "color: white; background-color: #337ab7;")
+    )
 )
 
-###### --------------- LATENESS UI INSIDE MODAL ------------- ####
-
-generate_lateness_ui <- function(lateness){
-    renderUI({ 
-        lapply(1:as.integer(lateness$num_late_cats), function(i) {
-            fluidRow(
-                
-                column(width = 3, offset = 0,
-                       selectInput(paste0("lateness_preposition", i), NULL,
-                                   ifelse(i <= length(lateness$prepositions),
-                                          lateness$prepositions[i],
-                                          "Until"
-                                   ),
-                                   choices = c("Until", "After", "Between"))
-                ),
-                column(width = 2, offset = 0,
-                       textInput(paste0("start", i), label = NULL,
-                                 value = ifelse(i <= length(lateness$starts),
-                                                lateness$starts[i],
-                                                ""
-                                 ),
-                                 placeholder = "HH:MM:SS"),
-                       #custom json to handle special time input
-                       #file is saved in folder www
-                       tags$head(includeScript("www/timeInputHandler.js"))
-                ),
-                column(width = 2, offset = 0,
-                       conditionalPanel(
-                           condition = paste0("input.lateness_preposition",i, "== 'Between'"),
-                           textInput(paste0("end", i), label = NULL, 
-                                     value = ifelse(i <= length(lateness$ends),
-                                                    lateness$ends[i],
-                                                    ""
-                                     ),
-                                     placeholder = "HH:MM:SS"),
-                           #custom json to handle special time input
-                           #file is saved in folder www
-                           tags$head(includeScript("www/timeInputHandler.js"))
-                       )
-                ),
-                column(width = 3, offset = 0,
-                       selectInput(paste0("lateness_arithmetic", i), NULL, 
-                                   ifelse(i <= length(lateness$arithmetics),
-                                          lateness$arithmetics[i],
-                                          "Add"
-                                   ),
-                                   
-                                   choices = c('Add' = 'Add',
-                                               'Scale By' = 'Scale_by', 
-                                               'Set To' = 'Set_to'
-                                   )
-                                   
-                       )
-                ),
-                column(width = 2, offset = 0,
-                       numericInput(paste0("lateness_value", i), label = NULL,
-                                    value = ifelse(i <= length(lateness$values),
-                                                   lateness$values[i],
-                                                   0.03
-                                                   
-                                    )
-                       )
-                )
-            )
-        })
+###### --------------- SLIP DAYS POLICIES UI ------------- ####
+createSlipDaysCards <- function(slip_days_table) {
+    lapply(names(slip_days_table), function(policy_name) {
+        slip_days_data <- slip_days_table[[policy_name]]
+        title <- div(class = "category-title", 
+                     slip_days_data$name,
+                     actionButton(paste0("slip_days_delete_", slip_days_data$name), 
+                                  label = NULL, 
+                                  icon = icon("trash"), 
+                                  style = "background-color: transparent; margin-right: 10px;"),
+                     actionButton(paste0("slip_days_edit_", slip_days_data$name), 
+                                  label = NULL, 
+                                  icon = icon("edit"), 
+                                  style = "background-color: transparent;")
+                     
+        )
+        content <- tags$div(
+            tags$strong("Number of Slip Days Allowed: "), slip_days_data$num_slip_days,
+            tags$br(),
+            tags$strong("Order: "), slip_days_data$order, 
+            tags$br(),
+            tags$strong("Assignments: "), paste(slip_days_data$assignments, collapse = ", ")
+        )
+        
+        box(
+            title = title,
+            status = "primary",
+            width = 8,
+            content
+        )
     })
 }
 
 
-###### --------------- SLIP DAYS POLICIES UI ------------- ####
-
-# 
-# createLatenessCards <- function(lateness_table) {
-#     lapply(names(lateness_table), function(late_policy_name) {
-#         late_policy <- lateness_table[[late_policy_name]]
-#         i <- 0.5
-#         content <- lapply(late_policy, function(item) {
-#             # Type of lateness and its value
-#             i <<- i + 0.5
-#             policy_line <- if (names(item) == "between") {
-#                 # Special format for BETWEEN
-#                 
-#                 tags$div(
-#                     tags$strong(paste0("INTERVAL ", i)),
-#                     tags$br(),
-#                     tags$strong(ucfirst(names(item))), 
-#                     tags$br(),
-#                     tags$strong("From:"), item$between$from,
-#                     tags$br(),
-#                     tags$strong("To:"), item$between$to,
-#                     tags$br()
-#                 )
-#             } else if(names(item) %in% c("until", "after")){
-#                 tags$div(
-#                     tags$strong(paste0("INTERVAL ", i)),
-#                     tags$br(),
-#                     tags$strong(ucfirst(names(item))), ":", item,
-#                     tags$br()
-#                 )
-#             } else {
-#                 tags$div(
-#                     tags$strong(ucfirst(names(item))), ":", item,
-#                     tags$br()
-#                 )
-#             }
-#             policy_line
-#         })
-#         
-#         
-#         icons <- div(
-#             class = "category-title",
-#             style = "text-align: right;", 
-#             # late_policy_name,
-#             actionButton(paste0('lateness_delete_', late_policy_name), label = NULL, icon = icon("trash"), style = "background-color: transparent; margin-right: 10px;"),
-#             actionButton(paste0('lateness_edit_', late_policy_name), label = NULL, icon = icon("edit"), style = "background-color: transparent;")
-#         )
-#         
-#         content <- do.call(tagList, content)
-#         
-#         box(
-#             #title = title,
-#             status = "primary",
-#             width = 8,
-#             icons,
-#             content
-#             
-#         )
-#     })
-# }
-
-# Helper function to capitalize the first letter of each word
-# ucfirst <- function(s) {
-#     sapply(strsplit(s, " "), function(x) {
-#         paste(toupper(substring(x, 1, 1)), substring(x, 2), sep = "", collapse = " ")
-#     }, USE.NAMES = FALSE)
-# }
-# 
-# update_lateness <- function(policy_categories, cat_to_update, late_policy){
-#     index <- find_indices(policy_categories, cat_to_update)
-#     index_cmd <- paste0("policy_categories[[", paste(index, collapse = "]]$assignments[["), "]]$lateness <- late_policy")
-#     eval(parse(text = index_cmd))
-#     return(policy_categories)
-# }
-
-###### --------------- FUNCTION TO GENERATE A STRING FOR EACH POLICY ------------- ####
-# format_policy <- function(policy) {
-#     policy_strings <- c()
-#     
-#     # Loop through each item in the policy
-#     for (interval in policy) {
-#         # Handle the 'between' interval
-#         if (!is.null(interval$between)) {
-#             between_string <- sprintf("Between: FROM: %s TO: %s", interval$between$from, interval$between$to)
-#             policy_strings <- c(policy_strings, between_string)
-#         } 
-#         
-#         # Handle the 'until' interval
-#         if (!is.null(interval$until)) {
-#             until_string <- sprintf("Until: %s", interval$until)
-#             policy_strings <- c(policy_strings, until_string)
-#         }
-#         
-#         # Handle the 'after' interval
-#         if (!is.null(interval$after)) {
-#             after_string <- sprintf("After: %s", interval$after)
-#             policy_strings <- c(policy_strings, after_string)
-#         }
-#         
-#         # Handle the 'add' arithmetic 
-#         if (!is.null(interval$add)) {
-#             add_string <- sprintf("Add: %s", interval$add)
-#             policy_strings <- c(policy_strings, add_string)
-#         }
-#         
-#         # Handle the 'scale by' arithmetic 
-#         if (!is.null(interval$scale_by)) {
-#             scaleby_string <- sprintf("Scale By: %s", interval$scale_by)
-#             policy_strings <- c(policy_strings, scaleby_string)
-#         }
-#         
-#         # Handle the 'set to' arithmetic 
-#         if (!is.null(interval$set_to)) {
-#             setto_string <- sprintf("Set To: %s", interval$set_to)
-#             policy_strings <- c(policy_strings, setto_string)
-#         }
-#     }
-#     #does not create a new line...
-#     paste(policy_strings, collapse = " ")
-# }
 ###### --------------- DELETE SLIP DAYS POLICY ------------- ####
-# confirm_delete_lateness <- modalDialog(
-#     h4("Are you sure you want to delete this lateness policy ?"),
-#     easyClose = TRUE,
-#     footer = tagList(
-#         actionButton("cancel", "Cancel"),
-#         actionButton("delete_late", "Delete"))
-#     
-# )
+confirm_delete_slip_days <- modalDialog(
+    h4("Are you sure you want to delete this slip days policy?"),
+    easyClose = TRUE,
+    footer = tagList(
+        actionButton("cancel", "Cancel"),
+        actionButton("delete_slip_days_confirm", "Delete")
+    )
+)
+

--- a/R/server.R
+++ b/R/server.R
@@ -11,6 +11,7 @@ HSLocation <- "helperscripts/"
 source(paste0(HSLocation, "assignments.R"), local = TRUE)
 source(paste0(HSLocation, "categories.R"), local = TRUE)
 source(paste0(HSLocation, "lateness.R"), local = TRUE)
+source(paste0(HSLocation, "slip_days.R"), local = TRUE)
 shinyServer(function(input, output, session) {
     
     #### -------------------------- UPLOADS ----------------------------####   
@@ -62,6 +63,7 @@ shinyServer(function(input, output, session) {
 
     #### -------------------------- POLICY ----------------------------####  
     policy <- reactiveValues(coursewide = list(course_name = "Course Name", description = "Description"),
+                             slip_days = list(),
                              categories = list(
                                  list(
                                      category = "Overall Grade",
@@ -589,6 +591,39 @@ shinyServer(function(input, output, session) {
         lateness$table[[lateness_to_be_deleted$policy]] <- NULL
         removeModal()
     }, ignoreInit = TRUE)
+    
+    
+    #### -------------------------- SLIP DAYS ----------------------------####
+    
+    slip_days <- reactiveValues(
+        default = NULL,
+        slip_days_policy_name = " ",
+        num_slip_days = 0, #number of slip days in a policy
+        order = "chronological", #order of applying slip days
+        assignments = list(), #which assignments are included
+        num_slip_days_cats = 1, #number of "slip days" policies existing in syllabus
+        table = list(),
+        edit = list(),
+        delete = list()
+    )
+    
+    # Opening category modal to create a NEW SLIP DAYS POLICY
+    observeEvent(input$new_slip_days, {
+        showModal(edit_slip_days_modal) #opens slip days modal
+        current_edit$slip_days <- NULL
+       # slip_days$slip_days_policy_name <- "New Slip Days Policy"
+        #slip_days$order <- 'chronological'
+        slip_days$assignments <- list()
+        slip_days$num_slip_days_cats <- 1
+        
+    })
+    
+    
+    
+    #### -------------------------- DISPLAY SLIP DAYS UI ----------------------------####
+    
+    
+    
     
     #### -------------------------- GRADING ----------------------------####
     

--- a/R/server.R
+++ b/R/server.R
@@ -22,7 +22,7 @@ shinyServer(function(input, output, session) {
     observeEvent(input$upload_gs,{
         req(input$upload_gs)
         tryCatch({
-            uploaded_data <- gradebook::read_gs(input$upload_gs$datapath)
+            uploaded_data <- gradebook::read_files(input$upload_gs$datapath)
             data(uploaded_data)
         }, error = function(e) {
             showNotification('Please upload a file with the Gradescope format','',type = "error")
@@ -646,6 +646,7 @@ shinyServer(function(input, output, session) {
             order = order,
             assignments = assignments
         )
+        
         
         # Check if editing an existing policy
         if (!is.null(slip_days$edit)) {

--- a/R/server.R
+++ b/R/server.R
@@ -476,9 +476,17 @@ shinyServer(function(input, output, session) {
         removeModal()
     })
     
-    observe({
-        final_policy <<- list(categories = policy$categories)
-    })
+    # observe({
+    #     final_policy <<- list(categories = policy$categories)
+    # })
+        observe({
+            final_policy <<- list(
+                coursewide = policy$coursewide,
+                slip_days = policy$slip_days,
+                categories = policy$categories
+            )
+        })
+
     
     #### -------------------------- ADVANCED LATENESS POLICIES UI ----------------------------####
     
@@ -594,35 +602,143 @@ shinyServer(function(input, output, session) {
     
     
     #### -------------------------- SLIP DAYS ----------------------------####
-    
+
     slip_days <- reactiveValues(
-        default = NULL,
-        slip_days_policy_name = " ",
-        num_slip_days = 0, #number of slip days in a policy
-        order = "chronological", #order of applying slip days
-        assignments = list(), #which assignments are included
-        num_slip_days_cats = 1, #number of "slip days" policies existing in syllabus
         table = list(),
-        edit = list(),
-        delete = list()
+        edit = NULL
     )
     
     # Opening category modal to create a NEW SLIP DAYS POLICY
     observeEvent(input$new_slip_days, {
-        showModal(edit_slip_days_modal) #opens slip days modal
+        showModal(edit_slip_days_modal)
         current_edit$slip_days <- NULL
-       # slip_days$slip_days_policy_name <- "New Slip Days Policy"
-        #slip_days$order <- 'chronological'
-        slip_days$assignments <- list()
-        slip_days$num_slip_days_cats <- 1
-        
+        updateTextInput(session, "slip_days_policy_name", value = "Slip Days Policy 1")
+        updateNumericInput(session, "num_slip_days", value = 0)
+        updateSelectInput(session, "slip_days_order", selected = "chronological")
+        if (!is.null(assign$table)) {
+            updateSelectizeInput(session, "assignments", choices = assign$table$assignment, selected = NULL)
+        }
     })
     
+    #Edit a slip day policy
+    observeEvent(input$edit_slip_days, {
+        req(current_edit$slip_days)
+        policy <- slip_days$table[[current_edit$slip_days]]
+        showModal(edit_slip_days_modal)
+        updateTextInput(session, "slip_days_policy_name", value = policy)
+        updateNumericInput(session, "num_slip_days", value = policy$num_slip_days)
+        updateSelectInput(session, "slip_days_order", selected = policy$order)
+        updateSelectizeInput(session, "assignments", choices = assign$table$assignment, selected = policy$assignments)
+    }, ignoreInit = TRUE)
+
+    #saving a slip day policy (both new and edit)
+    observeEvent(input$save_slip_days, {
+        req(input$slip_days_policy_name)
+        
+        policy_name <- input$slip_days_policy_name
+        num_days <- input$num_slip_days
+        order <- input$slip_days_order
+        assignments <- input$assignments
+        
+        new_policy <- list(
+            name = policy_name,
+            num_slip_days = num_days,
+            order = order,
+            assignments = assignments
+        )
+        
+        # Check if editing an existing policy
+        if (!is.null(slip_days$edit)) {
+            # Update the existing policy
+            slip_days$table[[slip_days$edit]] <- new_policy
+            policy$slip_days[[slip_days$edit]] <- new_policy
+            slip_days$edit <- NULL
+        } else {
+            # Check for duplicate names before adding a new policy
+            #Do not allow for duplicate names
+            if (policy_name %in% names(slip_days$table)) {
+                showNotification("Policy name already exists. Please choose a different name.", type = "error")
+            } else {
+                # Add the new policy
+                slip_days$table[[policy_name]] <- new_policy
+                policy$slip_days[[policy_name]] <- new_policy
+            }
+        }
+        
+        removeModal()
+        showNotification("Slip days policy saved successfully.", type = "message")
+    })
+
+    
+    observe({
+        lapply(names(slip_days$table), function(policy_name) {
+            
+            
+            observeEvent(input[[paste0("slip_days_edit_", policy_name)]], {
+                slip_days$edit <- policy_name
+                policy <- slip_days$table[[policy_name]]
+                
+                
+                showModal(edit_slip_days_modal)
+                updateTextInput(session, "slip_days_policy_name", value = policy$name)
+                updateNumericInput(session, "num_slip_days", value = policy$num_slip_days)
+                updateSelectInput(session, "slip_days_order", selected = policy$order)
+                updateSelectizeInput(session, "assignments", choices = assign$table$assignment, selected = policy$assignments)
+                #ignoreInIt is important for closure of modal to work properly!
+            }, ignoreInit = TRUE)
+        })
+    })
+    
+    #### -------------------------- DELETING SLIP DAYS POLICY ----------------------------####
+    
+    slip_days_to_be_deleted <- reactiveValues(policy = NULL)
+    
+    observe({
+        req(slip_days$table)
+        lapply(names(slip_days$table), function(policy_name) {
+            local({
+                # Localize the variables to ensure correct binding in the observer
+                local_policy_name <- policy_name
+                
+                observeEvent(input[[paste0("slip_days_delete_", local_policy_name)]], {
+                    matched_policy <- slip_days$table[[local_policy_name]]
+                    
+                    if (!is.null(matched_policy)) {
+                        showModal(confirm_delete_slip_days)
+                        slip_days_to_be_deleted$policy <- local_policy_name
+                    } else {
+                        showNotification("Please pick a valid slip days policy to delete.", type = "error")
+                    }
+                }, ignoreInit = TRUE)
+            })
+        })
+    })
+    
+    observeEvent(input$delete_slip_days_confirm, {
+        req(slip_days_to_be_deleted$policy)
+        
+        # Remove the policy from both slip_days$table and policy$slip_days
+        slip_days$table[[slip_days_to_be_deleted$policy]] <- NULL
+        policy$slip_days[[slip_days_to_be_deleted$policy]] <- NULL
+        
+        # Clear the reactive value -- otherwise delete confirmation shows up
+        #if you have deleted this slip day policy wit hteh same name before.
+        slip_days_to_be_deleted$policy <- NULL
+        
+        removeModal()
+        showNotification("Slip days policy deleted successfully.", type = "message")
+    }, ignoreInit = TRUE)
     
     
     #### -------------------------- DISPLAY SLIP DAYS UI ----------------------------####
     
     
+    output$slip_days_ui <- renderUI({
+        req(slip_days$table)
+        createSlipDaysCards(slip_days$table)
+    })
+    
+
     
     
     #### -------------------------- GRADING ----------------------------####
@@ -848,6 +964,7 @@ shinyServer(function(input, output, session) {
         },
         content = function(file) {
             yaml::write_yaml(list(coursewide = policy$coursewide,
+                                  slip_days = policy$slip_days,
                                   categories = policy$categories,
                                   exceptions = policy$exceptions), file)
         }

--- a/R/ui-components/policies.R
+++ b/R/ui-components/policies.R
@@ -64,15 +64,13 @@ Policies <- tabItem(tabName = "policies",
                                                  actionButton("new_lateness", label = NULL, icon = icon("plus"), style = "margin-top: -5px;  background-color: transparent; margin-right: 10px; color: #50A5EA;"),
                                                  hr(),
                                              )),
-                                         
-                                         
                                      )
                                  ),
                                  fluidRow(
                                     
                                      br(),
                                      fluidRow(style = "margin-left: 10px;"),
-                                     uiOutput("latenessUI"),
+                                     uiOutput("latenessUI")
                                  
                                  )
                                  
@@ -87,15 +85,12 @@ Policies <- tabItem(tabName = "policies",
                                                  actionButton("new_slip_days", label = NULL, icon = icon("plus"), style = "margin-top: -5px;  background-color: transparent; margin-right: 10px; color: #50A5EA;"),
                                                  hr(),
                                              )),
-                                         
-                                         
-                                     )
-                                 ),
+                                     )),
                                  fluidRow(
                                      
                                      br(),
                                      fluidRow(style = "margin-left: 10px;"),
-                                     uiOutput("latenessUI"),
+                                     uiOutput("slip_days_ui"),
                                      
                                  )
                                  

--- a/R/ui-components/policies.R
+++ b/R/ui-components/policies.R
@@ -76,6 +76,29 @@ Policies <- tabItem(tabName = "policies",
                                  
                                  )
                                  
+                        ),
+                        ### TAB SLIP DAYS ###
+                        tabPanel("Slip Days",
+                                 fluidRow(
+                                     tagList(
+                                         div(style = "align-items: center; padding: 20px; background-color: #ffffff;",
+                                             fluidRow(
+                                                 h4('Add New Slip Day Policy', style = " align-items: center;padding-left: 30px; font-size: 24px; display: inline-block; margin-right: 10px; " ),
+                                                 actionButton("new_slip_days", label = NULL, icon = icon("plus"), style = "margin-top: -5px;  background-color: transparent; margin-right: 10px; color: #50A5EA;"),
+                                                 hr(),
+                                             )),
+                                         
+                                         
+                                     )
+                                 ),
+                                 fluidRow(
+                                     
+                                     br(),
+                                     fluidRow(style = "margin-left: 10px;"),
+                                     uiOutput("latenessUI"),
+                                     
+                                 )
+                                 
                         )
                     )
 )

--- a/R/ui-components/policies.R
+++ b/R/ui-components/policies.R
@@ -81,7 +81,7 @@ Policies <- tabItem(tabName = "policies",
                                      tagList(
                                          div(style = "align-items: center; padding: 20px; background-color: #ffffff;",
                                              fluidRow(
-                                                 h4('Add New Slip Day Policy', style = " align-items: center;padding-left: 30px; font-size: 24px; display: inline-block; margin-right: 10px; " ),
+                                                 h4('Add New Slip Days Policy', style = " align-items: center;padding-left: 30px; font-size: 24px; display: inline-block; margin-right: 10px; " ),
                                                  actionButton("new_slip_days", label = NULL, icon = icon("plus"), style = "margin-top: -5px;  background-color: transparent; margin-right: 10px; color: #50A5EA;"),
                                                  hr(),
                                              )),


### PR DESCRIPTION
- [x] Adding a tab in Policies for Slip Days
- [x] Adding a Modal
- [x] UI cards to display slip days policies
- [x] build the following yaml structure:
```
coursewide:
  course_name: Stat 101
  description: Syllabus for gs_demo
slip_days:
  - name: "Slip Days 1"
    num_slip_days: 2
    order: chronological
    assignments:
        - "Lab 1"
        - "Lab 2"
        - "Lab 3"
        - "Lab 4"
        - "Lab 5"
        - "Lab 6"
categories:
  - category: Overall Grade
```

- [x] Edit/Delete Slip Days Policies
- [x] Add to Grading