### PR TITLE
(1)fixed data table to show even if no categories yet. (2)deleted lef…

### DIFF
--- a/R/server.R
+++ b/R/server.R
@@ -790,16 +790,20 @@ shinyServer(function(input, output, session) {
     
     output$course_data_table <- DT::renderDT({
         if (!is.null(grades())) {
-            # Process and display grades()
+            # Process and display grades() and do not show lateness columns
             grades_for_DT <- grades() |>
                 select(!ends_with(" - Submission Time")) |>
                 select(!ends_with(" - Lateness (H:M:S)")) |>
                 select(!contains("Total Lateness"))
             
-            datatable(grades_for_DT, options = list(scrollX = TRUE, scrollY = '300px'))
+            DT::datatable(grades_for_DT, options = list(scrollX = TRUE, scrollY = '300px'))
         } else if (!is.null(data())) {
+            data_for_DT <- data() |>
+                select(!ends_with(" - Submission Time")) |>
+                select(!ends_with(" - Lateness (H:M:S)")) |>
+                select(!contains("Total Lateness"))
             # Display data() even if no policy exists yet
-            datatable(data(), options = list(scrollX = TRUE, scrollY = '300px'))
+            DT::datatable(data_for_DT, options = list(scrollX = TRUE, scrollY = '300px'))
         }
     })
     

--- a/R/server.R
+++ b/R/server.R
@@ -669,9 +669,10 @@ shinyServer(function(input, output, session) {
                     height = '400px'
                 ),
                 box(
+                    title = 'Student Data',
                     DT::DTOutput('course_data_table'),
                     width = 12
-                )
+                    )
             )
         } else if (length(policy$categories) > 0) { # policy is created only
             tags$div(style = 'display: flex; flex-direction: column; justify-content: center; align-items: center; height: 60vh;',
@@ -787,17 +788,21 @@ shinyServer(function(input, output, session) {
         }
     })
     
-    output$course_data_table <- DT::renderDT({ 
-        if (!is.null(grades())){
-            # Don't display any lateness columns
+    output$course_data_table <- DT::renderDT({
+        if (!is.null(grades())) {
+            # Process and display grades()
             grades_for_DT <- grades() |>
                 select(!ends_with(" - Submission Time")) |>
                 select(!ends_with(" - Lateness (H:M:S)")) |>
                 select(!contains("Total Lateness"))
             
-            DT::datatable(grades_for_DT, options = list(scrollX = TRUE, scrollY = '500px'))
+            datatable(grades_for_DT, options = list(scrollX = TRUE, scrollY = '300px'))
+        } else if (!is.null(data())) {
+            # Display data() even if no policy exists yet
+            datatable(data(), options = list(scrollX = TRUE, scrollY = '300px'))
         }
     })
+    
     
     available_categories <- reactive({
         #can plot any category with valid assignments/nested categories
@@ -827,28 +832,5 @@ shinyServer(function(input, output, session) {
         }
     )
     
-    #### -------------------------- DATA FILES ----------------------------####   
-    # print out uploaded Gradescope data
-    output$original_gs <- DT::renderDT({
-        datatable(data(), options = list(scrollX = TRUE, scrollY = "500px"))
-    })
-    
-    #print out assignment table
-    output$assigns_table <- DT::renderDT({ assign$table })
-    
-    #shows policy$categories in Scratchpad under policy_list tab
-    output$policy_list <- renderPrint({
-        Hmisc::list.tree(list(coursewide = policy$coursewide, 
-                              categories = policy$categories, 
-                              letter_grades = policy$letter_grades,
-                              exceptions = policy$exceptions))
-    })
-    
-    output$flat_policy_list <- renderPrint({
-        Hmisc::list.tree(policy$flat)
-    })
-    
-    output$grades <- DT::renderDT({ 
-        datatable(grades(), options = list(scrollX = TRUE, scrollY = "500px"))
-    })
+
 })


### PR DESCRIPTION
- [x] display student data on dashboard even if no policy exists yet
- [ ] removed all "lateness" columns for both grades data and original uploaded student data @andrewpbray -- please confirm if you'd like no lateness columns or should I bring them back (in original student data)?
- [x] deleted leftover code from "Scratchpad", which does not exist anymore.